### PR TITLE
Ensure error controller returns appropriate status codes

### DIFF
--- a/src/FrontendAccountCreation.Web.UnitTests/Controllers/Error/AzureErrorControllerTests.cs
+++ b/src/FrontendAccountCreation.Web.UnitTests/Controllers/Error/AzureErrorControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using FrontendAccountCreation.Web.Constants;
 using FrontendAccountCreation.Web.Controllers.Errors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,29 @@ namespace FrontendAccountCreation.Web.UnitTests.Controllers.Error;
 [TestClass]
 public class AzureErrorControllerTests
 {
+    private AzureErrorController _systemUnderTest;
+    private Mock<HttpResponse> _mockHttpResponse;
+
+    [TestInitialize]
+    public void Init()
+    {
+        var mockHttpContext = new Mock<HttpContext>();
+        _mockHttpResponse = new Mock<HttpResponse>();
+
+        _mockHttpResponse.SetupProperty(r => r.StatusCode, (int)HttpStatusCode.OK);
+        mockHttpContext.Setup(c => c.Response).Returns(_mockHttpResponse.Object);
+
+        var controllerContext = new ControllerContext()
+        {
+            HttpContext = mockHttpContext.Object
+        };
+
+        _systemUnderTest = new AzureErrorController
+        {
+            ControllerContext = controllerContext
+        };
+    }
+
     [TestMethod]
     public void Error_ReturnsCorrectResult()
     {
@@ -28,5 +52,36 @@ public class AzureErrorControllerTests
         
 
     }
-    
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow((int)HttpStatusCode.NotFound)]
+    [DataRow((int)HttpStatusCode.InternalServerError)]
+    [DataRow((int)HttpStatusCode.BadRequest)]
+    public void Error_ReturnsErrorView_WhenCalledWithErrorCode(int? statusCode)
+    {
+        // Arrange
+        var httpStatusCode = (HttpStatusCode?)statusCode;
+        var expectedPageName = httpStatusCode switch
+        {
+            HttpStatusCode.NotFound => nameof(PagePath.PageNotFound),
+            _ => "AError"
+        };
+
+        // Act
+        var viewResult = _systemUnderTest.Error(statusCode);
+
+        // Assert
+        viewResult.ViewName.Should().Be(expectedPageName);
+
+        if (statusCode == null)
+        {
+            _systemUnderTest.Response.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+        }
+        else
+        {
+            _systemUnderTest.Response.StatusCode.Should().Be(statusCode);
+
+        }
+    }
 }

--- a/src/FrontendAccountCreation.Web.UnitTests/Controllers/Error/ErrorControllerTests.cs
+++ b/src/FrontendAccountCreation.Web.UnitTests/Controllers/Error/ErrorControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using FrontendAccountCreation.Web.Constants;
 using FrontendAccountCreation.Web.Controllers.Errors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,29 @@ namespace FrontendAccountCreation.Web.UnitTests.Controllers.Error;
 [TestClass]
 public class ErrorControllerTests
 {
+    private ErrorController _systemUnderTest;
+    private Mock<HttpResponse> _mockHttpResponse;
+
+    [TestInitialize]
+    public void Init()
+    {
+        var mockHttpContext = new Mock<HttpContext>();
+        _mockHttpResponse = new Mock<HttpResponse>();
+
+        _mockHttpResponse.SetupProperty(r => r.StatusCode, (int)HttpStatusCode.OK);
+        mockHttpContext.Setup(c => c.Response).Returns(_mockHttpResponse.Object);
+
+        var controllerContext = new ControllerContext()
+        {
+            HttpContext = mockHttpContext.Object
+        };
+
+        _systemUnderTest = new ErrorController
+        {
+            ControllerContext = controllerContext
+        };
+    }
+
     [TestMethod]
     public void Error_ReturnsCorrectResult()
     {
@@ -28,5 +52,37 @@ public class ErrorControllerTests
         
 
     }
-    
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow((int)HttpStatusCode.NotFound)]
+    [DataRow((int)HttpStatusCode.InternalServerError)]
+    [DataRow((int)HttpStatusCode.BadRequest)]
+    public void Error_ReturnsErrorView_WhenCalledWithErrorCode(int? statusCode)
+    {
+        // Arrange
+        var httpStatusCode = (HttpStatusCode?)statusCode;
+        var expectedPageName = httpStatusCode switch
+        {
+            HttpStatusCode.NotFound => nameof(PagePath.PageNotFound),
+            _ => "Error"
+        };
+
+        // Act
+        var viewResult = _systemUnderTest.Error(statusCode);
+
+        // Assert
+        viewResult.ViewName.Should().Be(expectedPageName);
+
+        if (statusCode == null)
+        {
+            _systemUnderTest.Response.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+        }
+        else
+        {
+            _systemUnderTest.Response.StatusCode.Should().Be(statusCode);
+
+        }
+    }
+
 }

--- a/src/FrontendAccountCreation.Web/Controllers/Errors/AzureErrorController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/Errors/AzureErrorController.cs
@@ -16,7 +16,7 @@ public class AzureErrorController : Controller
     {
         var errorView = statusCode == (int?)HttpStatusCode.NotFound ? PagePath.PageNotFound  : "AError";
 
-        Response.StatusCode = 200;
+        Response.StatusCode = statusCode ?? (int)HttpStatusCode.InternalServerError;
 
         return View(errorView);
     }

--- a/src/FrontendAccountCreation.Web/Controllers/Errors/ErrorController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/Errors/ErrorController.cs
@@ -16,7 +16,7 @@ public class ErrorController : Controller
     {
         var errorView = statusCode == (int?)HttpStatusCode.NotFound ? PagePath.PageNotFound : "Error";
 
-        Response.StatusCode = 200;
+        Response.StatusCode = statusCode ?? (int)HttpStatusCode.InternalServerError;
 
         return View(errorView);
     }

--- a/src/FrontendAccountCreation.Web/Program.cs
+++ b/src/FrontendAccountCreation.Web/Program.cs
@@ -6,6 +6,7 @@ using FrontendAccountCreation.Web.Middleware;
 
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Logging;
 
@@ -96,6 +97,13 @@ app.MapControllerRoute(
 app.MapHealthChecks(
     builder.Configuration.GetValue<string>("HealthCheckPath"),
     HealthCheckOptionBuilder.Build()).AllowAnonymous();
+app.MapHealthChecks("/admin/error", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+{
+    ResultStatusCodes =
+    {
+        [HealthStatus.Healthy] = StatusCodes.Status500InternalServerError
+    }
+}).AllowAnonymous();
 
 app.MapRazorPages();
 


### PR DESCRIPTION
The error controller previously always returned status 200. Now it returns the status code that was passed to it, or returns code 500 if the code that's passed to it is null.

Also added a health check endpoint for code 500.