### PR TITLE
AB#558441 increase code reuse by amalgamating methos in controllers

### DIFF
--- a/src/FrontendAccountCreation.Core/Sessions/AccountCreationSession.cs
+++ b/src/FrontendAccountCreation.Core/Sessions/AccountCreationSession.cs
@@ -1,9 +1,9 @@
-﻿namespace FrontendAccountCreation.Core.Sessions;
+﻿using FrontendAccountCreation.Core.Sessions.Interfaces;
 
-public class AccountCreationSession
+namespace FrontendAccountCreation.Core.Sessions;
+
+public class AccountCreationSession : ILocalSession
 {
-    public List<string> Journey { get; set; } = new();
-
     public bool IsTheOrganisationCharity { get; set; }
 
     public OrganisationType? OrganisationType { get; set; }
@@ -26,9 +26,11 @@ public class AccountCreationSession
 
     public bool IsManualInputFlow => OrganisationType == Sessions.OrganisationType.NonCompaniesHouseCompany;
 
-    public bool IsUserChangingDetails { get; set; }
-    
     public bool IsApprovedUser { get; set; }
     
     public string OrganisationId { get; set; }
+
+    public bool IsUserChangingDetails { get; set; }
+    public List<string> Journey { get; set; } = new();
+
 }

--- a/src/FrontendAccountCreation.Core/Sessions/Interfaces/ILocalSession.cs
+++ b/src/FrontendAccountCreation.Core/Sessions/Interfaces/ILocalSession.cs
@@ -1,0 +1,8 @@
+﻿namespace FrontendAccountCreation.Core.Sessions.Interfaces;
+
+public interface ILocalSession
+{
+    public List<string> Journey { get; set; }
+
+    public bool IsUserChangingDetails { get; set; }
+}

--- a/src/FrontendAccountCreation.Core/Sessions/ReEx/OrganisationSession.cs
+++ b/src/FrontendAccountCreation.Core/Sessions/ReEx/OrganisationSession.cs
@@ -1,9 +1,9 @@
-﻿namespace FrontendAccountCreation.Core.Sessions.ReEx;
+﻿using FrontendAccountCreation.Core.Sessions.Interfaces;
 
-public class OrganisationSession
+namespace FrontendAccountCreation.Core.Sessions.ReEx;
+
+public class OrganisationSession : ILocalSession
 {
-    public List<string> Journey { get; set; } = [];
-
     public bool? IsTheOrganisationCharity { get; set; }
 
     public OrganisationType? OrganisationType { get; set; }
@@ -28,11 +28,13 @@ public class OrganisationSession
 
     public bool IsCompaniesHouseFlow => OrganisationType == Sessions.OrganisationType.CompaniesHouseCompany;
 
-    public bool IsUserChangingDetails { get; set; }
-
     public bool IsApprovedUser { get; set; }
 
     public bool? IsTradingNameDifferent { get; set; }
 
     public bool? IsOrganisationAPartnership { get; set; }
+
+    public bool IsUserChangingDetails { get; set; }
+
+    public List<string> Journey { get; set; } = [];
 }

--- a/src/FrontendAccountCreation.Core/Sessions/ReExAccountCreationSession.cs
+++ b/src/FrontendAccountCreation.Core/Sessions/ReExAccountCreationSession.cs
@@ -1,8 +1,10 @@
-﻿namespace FrontendAccountCreation.Core.Sessions;
+﻿using FrontendAccountCreation.Core.Sessions.Interfaces;
 
-public class ReExAccountCreationSession
+namespace FrontendAccountCreation.Core.Sessions;
+
+public class ReExAccountCreationSession : ILocalSession
 {
-    public List<string> Journey { get; set; } = new();
-
     public ReExContact? Contact { get; set; } = new();
+    public bool IsUserChangingDetails { get; set; }
+    public List<string> Journey { get; set; } = new();
 }

--- a/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
+++ b/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
@@ -1,0 +1,58 @@
+﻿using FrontendAccountCreation.Core.Sessions.ReEx.Partnership;
+using FrontendAccountCreation.Core.Sessions.ReEx;
+using FrontendAccountCreation.Web.Constants;
+using Moq;
+using Microsoft.AspNetCore.Http;
+using FluentAssertions;
+
+namespace FrontendAccountCreation.Web.UnitTests.Controllers.ReprocessorExporter.LimitedPartnership;
+
+[TestClass]
+public class LimitedPartnershipControllerTests : LimitedPartnershipTestBase
+{
+    [TestInitialize]
+    public void Setup()
+    {
+        SetupBase();
+
+        _orgSessionMock = new OrganisationSession
+        {
+            Journey = new List<string>
+            {
+                PagePath.IsPartnership,
+                PagePath.PartnershipType,
+                PagePath.LimitedPartnershipType,
+                PagePath.LimitedPartnershipNamesOfPartners,
+                PagePath.LimitedPartnershipCheckNamesOfPartners
+            },
+            IsOrganisationAPartnership = true,
+            ReExCompaniesHouseSession = new ReExCompaniesHouseSession
+            {
+                Partnership = new ReExPartnership
+                {
+                    IsLimitedPartnership = true,
+                    LimitedPartnership = new ReExLimitedPartnership()
+                }
+            }
+        };
+
+        _sessionManagerMock.Setup(x => x.GetSessionAsync(It.IsAny<ISession>()))
+            .ReturnsAsync(_orgSessionMock);
+    }
+
+    [TestMethod]
+    [DataRow("", "check-your-details")]
+    [DataRow("MyPage", "check-your-details")]
+    [DataRow("check-your-details", "")]
+    public void SetBackLink_When_IsUserChangingDetails_Is_True_Updates_ViewBag(string currentPagePath, string expectedValue)
+    {
+        // Arrange
+        _orgSessionMock.IsUserChangingDetails = true;
+
+        // Act
+        _systemUnderTest.SetBackLink(_orgSessionMock, currentPagePath);
+
+        // Assert
+        _systemUnderTest.ViewData["BackLinkToDisplay"].ToString().Should().Be(expectedValue);
+    }
+}

--- a/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
+++ b/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
@@ -175,12 +175,18 @@ public class LimitedPartnershipControllerTests : LimitedPartnershipTestBase
     }
 
     [TestMethod]
-    public async Task SaveSession_UpdatesSession()
+    public async Task SaveSession_UpdatessJourneyInSession()
     {
+        // Arrange
+        string currentPagePath = PagePath.LimitedPartnershipCheckNamesOfPartners;
+        string nextPath = "MyNextPage";
+
         // Act
-        await _systemUnderTest.SaveSession(_orgSessionMock, null, null);
+        await _systemUnderTest.SaveSession(_orgSessionMock, currentPagePath, nextPath);
 
         // Assert
         _sessionManagerMock.Verify(x => x.SaveSessionAsync(It.IsAny<ISession>(), _orgSessionMock), Times.Once());
+
+        _orgSessionMock.Journey.Should().ContainInOrder(currentPagePath, nextPath);
     }
 }

--- a/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
+++ b/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
@@ -5,6 +5,7 @@ using FrontendAccountCreation.Web.Constants;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using System.Collections.Specialized;
 
 namespace FrontendAccountCreation.Web.UnitTests.Controllers.ReprocessorExporter.LimitedPartnership;
 
@@ -84,7 +85,7 @@ public class LimitedPartnershipControllerTests : LimitedPartnershipTestBase
         _orgSessionMock.IsUserChangingDetails = true;
 
         // Act
-        var result = await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, string.Empty, string.Empty, null);
+        await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, string.Empty, string.Empty, null);
 
         // Assert
         _orgSessionMock.IsUserChangingDetails.Should().BeFalse();
@@ -99,5 +100,74 @@ public class LimitedPartnershipControllerTests : LimitedPartnershipTestBase
         // Assert
         var redirectToActionResult = result.Should().BeOfType<RedirectToActionResult>().Which;
         redirectToActionResult.ActionName.Should().Be("myAction");
+        redirectToActionResult.ControllerName.Should().BeNull();
+        redirectToActionResult.RouteValues.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task SaveSessionAndRedirect_WhenGivenAction_AndController_Flags_IsUserChangingDetails_False()
+    {
+        // Arrange
+        _orgSessionMock.IsUserChangingDetails = true;
+
+        // Act
+        await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, string.Empty, string.Empty, string.Empty, null);
+
+        // Assert
+        _orgSessionMock.IsUserChangingDetails.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task SaveSessionAndRedirect_WhenGivenAction_AndController_Redirects()
+    {
+        // Act
+        var result = await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, "herController", "myAction", string.Empty, null);
+
+        // Assert
+        var redirectToActionResult = result.Should().BeOfType<RedirectToActionResult>().Which;
+        redirectToActionResult.ActionName.Should().Be("myAction");
+        redirectToActionResult.ControllerName.Should().Be("her");
+        redirectToActionResult.RouteValues.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task SaveSessionAndRedirect_WhenGivenAction_AndController_AndQueryString_Flags_IsUserChangingDetails_False()
+    {
+        // Arrange
+        _orgSessionMock.IsUserChangingDetails = true;
+
+        // Act
+        await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, string.Empty, string.Empty, null, null, null);
+
+        // Assert
+        _orgSessionMock.IsUserChangingDetails.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task SaveSessionAndRedirect_WhenGivenAction_AndBlankControllerr_AndQueryString_Redirects()
+    {
+        // Act
+        var querystring = new KeyValuePair<string, string>("x", "y") as object;
+        var result = await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, "myAction", string.Empty, null, null, querystring);
+
+        // Assert
+        var redirectToActionResult = result.Should().BeOfType<RedirectToActionResult>().Which;
+        redirectToActionResult.ActionName.Should().Be("myAction");
+        redirectToActionResult.ControllerName.Should().BeNull();
+        redirectToActionResult.RouteValues.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public async Task SaveSessionAndRedirect_WhenGivenAction_AndControllerr_AndQueryString_Redirects()
+    {
+        // Act
+        var querystring = new KeyValuePair<string, string>("x", "y") as object;
+        var result = await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, "myAction", string.Empty, null, "herController", querystring);
+
+        // Assert
+        var redirectToActionResult = result.Should().BeOfType<RedirectToActionResult>().Which;
+        redirectToActionResult.ActionName.Should().Be("myAction");
+        redirectToActionResult.ControllerName.Should().Be("her");
+        redirectToActionResult.RouteValues.Should().HaveCount(2);
     }
 }

--- a/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
+++ b/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
@@ -1,9 +1,10 @@
-﻿using FrontendAccountCreation.Core.Sessions.ReEx.Partnership;
+﻿using FluentAssertions;
 using FrontendAccountCreation.Core.Sessions.ReEx;
+using FrontendAccountCreation.Core.Sessions.ReEx.Partnership;
 using FrontendAccountCreation.Web.Constants;
-using Moq;
 using Microsoft.AspNetCore.Http;
-using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
 
 namespace FrontendAccountCreation.Web.UnitTests.Controllers.ReprocessorExporter.LimitedPartnership;
 
@@ -74,5 +75,29 @@ public class LimitedPartnershipControllerTests : LimitedPartnershipTestBase
 
         // Assert
         _systemUnderTest.ViewData["BackLinkToDisplay"].ToString().Should().Be(expectedValue);
+    }
+
+    [TestMethod]
+    public async Task SaveSessionAndRedirect_WhenGivenAction_Flags_IsUserChangingDetails_False()
+    {
+        // Arrange
+        _orgSessionMock.IsUserChangingDetails = true;
+
+        // Act
+        var result = await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, string.Empty, string.Empty, null);
+
+        // Assert
+        _orgSessionMock.IsUserChangingDetails.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task SaveSessionAndRedirect_WhenGivenAction_Redirects()
+    {
+        // Act
+        var result = await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, "myAction", string.Empty, null);
+
+        // Assert
+        var redirectToActionResult = result.Should().BeOfType<RedirectToActionResult>().Which;
+        redirectToActionResult.ActionName.Should().Be("myAction");
     }
 }

--- a/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
+++ b/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
@@ -5,7 +5,6 @@ using FrontendAccountCreation.Web.Constants;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
-using System.Collections.Specialized;
 
 namespace FrontendAccountCreation.Web.UnitTests.Controllers.ReprocessorExporter.LimitedPartnership;
 
@@ -146,8 +145,10 @@ public class LimitedPartnershipControllerTests : LimitedPartnershipTestBase
     [TestMethod]
     public async Task SaveSessionAndRedirect_WhenGivenAction_AndBlankControllerr_AndQueryString_Redirects()
     {
-        // Act
+        // Arrange
         var querystring = new KeyValuePair<string, string>("x", "y") as object;
+
+        // Act
         var result = await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, "myAction", string.Empty, null, null, querystring);
 
         // Assert
@@ -160,8 +161,10 @@ public class LimitedPartnershipControllerTests : LimitedPartnershipTestBase
     [TestMethod]
     public async Task SaveSessionAndRedirect_WhenGivenAction_AndControllerr_AndQueryString_Redirects()
     {
-        // Act
+        // Arrange
         var querystring = new KeyValuePair<string, string>("x", "y") as object;
+
+        // Act
         var result = await _systemUnderTest.SaveSessionAndRedirect(_orgSessionMock, "myAction", string.Empty, null, "herController", querystring);
 
         // Assert
@@ -169,5 +172,15 @@ public class LimitedPartnershipControllerTests : LimitedPartnershipTestBase
         redirectToActionResult.ActionName.Should().Be("myAction");
         redirectToActionResult.ControllerName.Should().Be("her");
         redirectToActionResult.RouteValues.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public async Task SaveSession_UpdatesSession()
+    {
+        // Act
+        await _systemUnderTest.SaveSession(_orgSessionMock, null, null);
+
+        // Assert
+        _sessionManagerMock.Verify(x => x.SaveSessionAsync(It.IsAny<ISession>(), _orgSessionMock), Times.Once());
     }
 }

--- a/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
+++ b/src/FrontendAccountCreation.Web.UnitTests/Controllers/ReprocessorExporter/LimitedPartnership/LimitedPartnershipControllerTests.cs
@@ -55,4 +55,24 @@ public class LimitedPartnershipControllerTests : LimitedPartnershipTestBase
         // Assert
         _systemUnderTest.ViewData["BackLinkToDisplay"].ToString().Should().Be(expectedValue);
     }
+
+    [TestMethod]
+    [DataRow("", "")]
+    [DataRow("MyPage", "")]
+    [DataRow(PagePath.LimitedPartnershipCheckNamesOfPartners, PagePath.LimitedPartnershipNamesOfPartners)]
+    [DataRow(PagePath.LimitedPartnershipNamesOfPartners, PagePath.LimitedPartnershipType)]
+    [DataRow(PagePath.LimitedPartnershipType, PagePath.PartnershipType)]
+    [DataRow(PagePath.PartnershipType, PagePath.IsPartnership)]
+    [DataRow(PagePath.IsPartnership, "")]
+    public void SetBackLink_When_IsUserChangingDetails_Is_False_Updates_ViewBag(string currentPagePath, string expectedValue)
+    {
+        // Arrange
+        _orgSessionMock.IsUserChangingDetails = false;
+
+        // Act
+        _systemUnderTest.SetBackLink(_orgSessionMock, currentPagePath);
+
+        // Assert
+        _systemUnderTest.ViewData["BackLinkToDisplay"].ToString().Should().Be(expectedValue);
+    }
 }

--- a/src/FrontendAccountCreation.Web.UnitTests/Extensions/StringExtensionTests.cs
+++ b/src/FrontendAccountCreation.Web.UnitTests/Extensions/StringExtensionTests.cs
@@ -1,0 +1,21 @@
+﻿using FluentAssertions;
+using FrontendAccountCreation.Web.Extensions;
+
+namespace FrontendAccountCreation.Web.UnitTests.Extensions;
+
+[TestClass]
+public class StringExtensionTests
+{
+    [TestMethod]
+    [DataRow(null, null)]
+    [DataRow("", "")]
+    [DataRow("Bla", "Bla")]
+    [DataRow("Controller1", "Controller1")]
+    [DataRow("Controller", "")]
+    [DataRow("MyController", "My")]
+    [DataRow("MyCONTROLLER", "My")]
+    public void WithoutControllerSuffix_Returns_Name_With_The_Word_Controller_Stripped_From_Ending(string rawName, string expectedControllerName)
+    {
+        rawName.WithoutControllerSuffix().Should().Be(expectedControllerName);
+    }
+}

--- a/src/FrontendAccountCreation.Web/Constants/PagePath.cs
+++ b/src/FrontendAccountCreation.Web/Constants/PagePath.cs
@@ -53,7 +53,7 @@ public static class PagePath
     public const string LimitedPartnershipNamesOfPartners = "organisation-enter-corporate-individual-partner-names";
     public const string LimitedPartnershipCheckNamesOfPartners = "organisation-check-corporate-individual-partner-names";
     public const string PartnershipType= "partnership-type";
-    public const string LimitedPartnershipType = "limited-partnership-type";
+    public const string LimitedPartnershipType = "organisation-partnership-type";
     public const string LimitedPartnershipRole = "organisation-your-role-in-limited-partnership";
     public const string LimitedPartnershipYouAreApprovedPerson = "you-are-now-an-approved-person";
     // Non journey paths 

--- a/src/FrontendAccountCreation.Web/Controllers/AccountCreation/AccountCreationController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/AccountCreation/AccountCreationController.cs
@@ -8,7 +8,6 @@ using Constants;
 using Core.Addresses;
 using Core.Constants;
 using Core.Exceptions;
-using Core.Extensions;
 using Core.Services;
 using Core.Services.Dto.Company;
 using Core.Services.FacadeModels;
@@ -25,7 +24,6 @@ using ViewModels;
 using ViewModels.AccountCreation;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System.Text.Json;
-using FrontendAccountCreation.Web.Controllers.ReprocessorExporter;
 
 public class AccountCreationController : ControllerBase<AccountCreationSession>
 {

--- a/src/FrontendAccountCreation.Web/Controllers/ControllerBase.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ControllerBase.cs
@@ -54,6 +54,7 @@ public abstract class ControllerBase<T> : Controller where T : ILocalSession, ne
         return RedirectToAction(actionName, controllerName.WithoutControllerSuffix());
     }
 
+    // Would like to get parameters in same order as above
     public async Task<RedirectToActionResult> SaveSessionAndRedirect(T session,
         string actionName,
         string currentPagePath,

--- a/src/FrontendAccountCreation.Web/Controllers/ControllerBase.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ControllerBase.cs
@@ -7,15 +7,13 @@ using FrontendAccountCreation;
 using FrontendAccountCreation.Web;
 using FrontendAccountCreation.Web.Controllers;
 
-using FrontendAccountCreation.Web.Controllers;
-
 namespace FrontendAccountCreation.Web.Controllers;
 
 public abstract class ControllerBase<T> : Controller where T : ILocalSession, new()
 {
     private readonly ISessionManager<T> _sessionManager;
 
-    public ControllerBase(ISessionManager<T> sessionManager)
+    protected ControllerBase(ISessionManager<T> sessionManager)
     {
         _sessionManager = sessionManager;
     }
@@ -56,7 +54,6 @@ public abstract class ControllerBase<T> : Controller where T : ILocalSession, ne
         return RedirectToAction(actionName, contNameWOCont);
     }
 
-
     public async Task<RedirectToActionResult> SaveSessionAndRedirect(T session,
         string actionName,
         string currentPagePath,
@@ -76,7 +73,6 @@ public abstract class ControllerBase<T> : Controller where T : ILocalSession, ne
             return RedirectToAction(actionName, routeValues);
         }
     }
-
 
     public async Task SaveSession(T session, string currentPagePath, string? nextPagePath)
     {

--- a/src/FrontendAccountCreation.Web/Controllers/ControllerBase.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ControllerBase.cs
@@ -6,6 +6,7 @@ using FrontendAccountCreation.Web.Sessions;
 using FrontendAccountCreation;
 using FrontendAccountCreation.Web;
 using FrontendAccountCreation.Web.Controllers;
+using FrontendAccountCreation.Web.Extensions;
 
 namespace FrontendAccountCreation.Web.Controllers;
 
@@ -48,10 +49,9 @@ public abstract class ControllerBase<T> : Controller where T : ILocalSession, ne
         string? nextPagePath)
     {
         session.IsUserChangingDetails = false;
-        var contNameWOCont = controllerName.Replace("Controller", string.Empty);
         await SaveSession(session, currentPagePath, nextPagePath);
 
-        return RedirectToAction(actionName, contNameWOCont);
+        return RedirectToAction(actionName, controllerName.WithoutControllerSuffix());
     }
 
     public async Task<RedirectToActionResult> SaveSessionAndRedirect(T session,
@@ -66,7 +66,7 @@ public abstract class ControllerBase<T> : Controller where T : ILocalSession, ne
 
         if (!string.IsNullOrWhiteSpace(controllerName))
         {
-            return RedirectToAction(actionName, controllerName, routeValues);
+            return RedirectToAction(actionName, controllerName.WithoutControllerSuffix(), routeValues);
         }
         else
         {

--- a/src/FrontendAccountCreation.Web/Controllers/ControllerBase.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ControllerBase.cs
@@ -1,12 +1,15 @@
 ﻿using FrontendAccountCreation.Core.Extensions;
-using FrontendAccountCreation.Core.Sessions;
 using FrontendAccountCreation.Core.Sessions.Interfaces;
-using FrontendAccountCreation.Core.Sessions.ReEx;
 using FrontendAccountCreation.Web.Constants;
 using Microsoft.AspNetCore.Mvc;
 using FrontendAccountCreation.Web.Sessions;
+using FrontendAccountCreation;
+using FrontendAccountCreation.Web;
+using FrontendAccountCreation.Web.Controllers;
 
-namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter;
+using FrontendAccountCreation.Web.Controllers;
+
+namespace FrontendAccountCreation.Web.Controllers;
 
 public abstract class ControllerBase<T> : Controller where T : ILocalSession, new()
 {
@@ -29,8 +32,7 @@ public abstract class ControllerBase<T> : Controller where T : ILocalSession, ne
         }
     }
 
-    public async Task<RedirectToActionResult> SaveSessionAndRedirect(
-        T session,
+    public async Task<RedirectToActionResult> SaveSessionAndRedirect(T session,
         string actionName,
         string currentPagePath,
         string? nextPagePath)
@@ -41,8 +43,7 @@ public abstract class ControllerBase<T> : Controller where T : ILocalSession, ne
         return RedirectToAction(actionName);
     }
 
-    public async Task<RedirectToActionResult> SaveSessionAndRedirect(
-        T session,
+    public async Task<RedirectToActionResult> SaveSessionAndRedirect(T session,
         string controllerName,
         string actionName,
         string currentPagePath,
@@ -55,18 +56,27 @@ public abstract class ControllerBase<T> : Controller where T : ILocalSession, ne
         return RedirectToAction(actionName, contNameWOCont);
     }
 
+
     public async Task<RedirectToActionResult> SaveSessionAndRedirect(T session,
         string actionName,
         string currentPagePath,
         string? nextPagePath,
-        string? controllerName = null,
-        object? routeValues = null)
+        string? controllerName,
+        object? routeValues)
     {
         session.IsUserChangingDetails = false;
         await SaveSession(session, currentPagePath, nextPagePath);
 
-        return !string.IsNullOrWhiteSpace(controllerName) ? RedirectToAction(actionName, controllerName, routeValues) : RedirectToAction(actionName, routeValues);
+        if (!string.IsNullOrWhiteSpace(controllerName))
+        {
+            return RedirectToAction(actionName, controllerName, routeValues);
+        }
+        else
+        {
+            return RedirectToAction(actionName, routeValues);
+        }
     }
+
 
     public async Task SaveSession(T session, string currentPagePath, string? nextPagePath)
     {

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/ApprovedPersonController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/ApprovedPersonController.cs
@@ -3,6 +3,7 @@ using FrontendAccountCreation.Core.Sessions;
 using FrontendAccountCreation.Core.Sessions.ReEx;
 using FrontendAccountCreation.Web.Configs;
 using FrontendAccountCreation.Web.Constants;
+using FrontendAccountCreation.Web.Controllers;
 using FrontendAccountCreation.Web.Controllers.Attributes;
 using FrontendAccountCreation.Web.Sessions;
 using FrontendAccountCreation.Web.ViewModels.ReExAccount;
@@ -346,51 +347,6 @@ namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter
         public IActionResult PersonCanNotBeInvited(LimitedPartnershipPersonCanNotBeInvitedViewModel model)
         {
             return RedirectToAction("CheckYourDetails", "AccountCreation");
-        }
-
-        [ExcludeFromCodeCoverage(Justification = "Going to be refactored into separate common classes")]
-        private async Task<RedirectToActionResult> SaveSessionAndRedirect(OrganisationSession session,
-            string actionName, string currentPagePath, string? nextPagePath, string? controllerName = null, object? routeValues = null)
-        {
-            session.IsUserChangingDetails = false;
-            await SaveSession(session, currentPagePath, nextPagePath);
-
-            return !string.IsNullOrWhiteSpace(controllerName) ? RedirectToAction(actionName, controllerName, routeValues) : RedirectToAction(actionName, routeValues);
-        }
-
-        [ExcludeFromCodeCoverage(Justification = "Going to be refactored into separate common classes")]
-        private async Task SaveSession(OrganisationSession session, string currentPagePath, string? nextPagePath)
-        {
-            ClearRestOfJourney(session, currentPagePath);
-            if (nextPagePath == PagePath.TeamMembersCheckInvitationDetails)
-            {
-                session.Journey.AddIfNotExists(PagePath.TeamMemberDetails);
-            }
-            session.Journey.AddIfNotExists(nextPagePath);
-
-            await _sessionManager.SaveSessionAsync(HttpContext.Session, session);
-        }
-
-        [ExcludeFromCodeCoverage(Justification = "Going to be refactored into separate common classes")]
-        private static void ClearRestOfJourney(OrganisationSession session, string currentPagePath)
-        {
-            var index = session.Journey.FindIndex(x => x.Contains(currentPagePath.Split("?")[0]));
-
-            // this also cover if current page not found (index = -1) then it clears all pages
-            session.Journey = session.Journey.Take(index + 1).ToList();
-        }
-
-        [ExcludeFromCodeCoverage(Justification = "Going to be refactored into separate common classes")]
-        private void SetBackLink(OrganisationSession session, string currentPagePath)
-        {
-            if (session.IsUserChangingDetails && currentPagePath != PagePath.CheckYourDetails)
-            {
-                ViewBag.BackLinkToDisplay = PagePath.CheckYourDetails;
-            }
-            else
-            {
-                ViewBag.BackLinkToDisplay = session.Journey.PreviousOrDefault(currentPagePath) ?? string.Empty;
-            }
         }
     }
 }

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/ApprovedPersonController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/ApprovedPersonController.cs
@@ -9,20 +9,19 @@ using FrontendAccountCreation.Web.ViewModels.ReExAccount;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using System.Diagnostics.CodeAnalysis;
-using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
-
 
 namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter
 {
     [Feature(FeatureFlags.AddOrganisationCompanyHouseDirectorJourney)]
     [Route("re-ex/organisation")]
-    public partial class ApprovedPersonController : Controller
+    public partial class ApprovedPersonController : ControllerBase<OrganisationSession>
     {
         private readonly ISessionManager<OrganisationSession> _sessionManager;
         private readonly ExternalUrlsOptions _urlOptions;
 
-        public ApprovedPersonController(ISessionManager<OrganisationSession> sessionManager,
-        IOptions<ExternalUrlsOptions> urlOptions)
+        public ApprovedPersonController(
+            ISessionManager<OrganisationSession> sessionManager,
+            IOptions<ExternalUrlsOptions> urlOptions) : base(sessionManager)
         {
             _sessionManager = sessionManager;
             _urlOptions = urlOptions.Value;
@@ -337,7 +336,7 @@ namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter
             var session = await _sessionManager.GetSessionAsync(HttpContext.Session);
             SetBackLink(session, PagePath.ApprovedPersonPartnershipCanNotBeInvited);
             await _sessionManager.SaveSessionAsync(HttpContext.Session, session);
-            
+
             return View(new LimitedPartnershipPersonCanNotBeInvitedViewModel { Id = id });
         }
 

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/ControllerBase.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/ControllerBase.cs
@@ -1,0 +1,82 @@
+﻿using FrontendAccountCreation.Core.Extensions;
+using FrontendAccountCreation.Core.Sessions;
+using FrontendAccountCreation.Core.Sessions.Interfaces;
+using FrontendAccountCreation.Core.Sessions.ReEx;
+using FrontendAccountCreation.Web.Constants;
+using Microsoft.AspNetCore.Mvc;
+using FrontendAccountCreation.Web.Sessions;
+
+namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter;
+
+public abstract class ControllerBase<T> : Controller where T : ILocalSession, new()
+{
+    private readonly ISessionManager<T> _sessionManager;
+
+    public ControllerBase(ISessionManager<T> sessionManager)
+    {
+        _sessionManager = sessionManager;
+    }
+
+    public void SetBackLink(T session, string currentPagePath)
+    {
+        if (session.IsUserChangingDetails && currentPagePath != PagePath.CheckYourDetails)
+        {
+            ViewBag.BackLinkToDisplay = PagePath.CheckYourDetails;
+        }
+        else
+        {
+            ViewBag.BackLinkToDisplay = session.Journey.PreviousOrDefault(currentPagePath) ?? string.Empty;
+        }
+    }
+
+    public async Task<RedirectToActionResult> SaveSessionAndRedirect(
+        T session,
+        string actionName,
+        string currentPagePath,
+        string? nextPagePath)
+    {
+        session.IsUserChangingDetails = false;
+        await SaveSession(session, currentPagePath, nextPagePath);
+
+        return RedirectToAction(actionName);
+    }
+
+    public async Task<RedirectToActionResult> SaveSessionAndRedirect(
+        T session,
+        string controllerName,
+        string actionName,
+        string currentPagePath,
+        string? nextPagePath)
+    {
+        session.IsUserChangingDetails = false;
+        var contNameWOCont = controllerName.Replace("Controller", string.Empty);
+        await SaveSession(session, currentPagePath, nextPagePath);
+
+        return RedirectToAction(actionName, contNameWOCont);
+    }
+
+    public async Task<RedirectToActionResult> SaveSessionAndRedirect(T session,
+        string actionName,
+        string currentPagePath,
+        string? nextPagePath,
+        string? controllerName = null,
+        object? routeValues = null)
+    {
+        session.IsUserChangingDetails = false;
+        await SaveSession(session, currentPagePath, nextPagePath);
+
+        return !string.IsNullOrWhiteSpace(controllerName) ? RedirectToAction(actionName, controllerName, routeValues) : RedirectToAction(actionName, routeValues);
+    }
+
+    public async Task SaveSession(T session, string currentPagePath, string? nextPagePath)
+    {
+        var index = session.Journey.IndexOf(currentPagePath);
+
+        // this also cover if current page not found (index = -1) then it clears all pages
+        session.Journey = session.Journey.Take(index + 1).ToList();
+
+        session.Journey.AddIfNotExists(nextPagePath);
+
+        await _sessionManager.SaveSessionAsync(HttpContext.Session, session);
+    }
+}

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/LimitedPartnershipController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/LimitedPartnershipController.cs
@@ -1,4 +1,4 @@
-﻿using FrontendAccountCreation.Core.Extensions;
+﻿using FrontendAccountCreation.Core.Sessions.Interfaces;
 using FrontendAccountCreation.Core.Sessions.ReEx;
 using FrontendAccountCreation.Core.Sessions.ReEx.Partnership;
 using FrontendAccountCreation.Web.Constants;
@@ -6,17 +6,16 @@ using FrontendAccountCreation.Web.Controllers.Attributes;
 using FrontendAccountCreation.Web.Sessions;
 using FrontendAccountCreation.Web.ViewModels.ReExAccount;
 using Microsoft.AspNetCore.Mvc;
-using System.Diagnostics.CodeAnalysis;
 
 namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter;
 
 [Feature(FeatureFlags.AddOrganisationCompanyHouseDirectorJourney)]
 [Route("re-ex/organisation")]
-public partial class LimitedPartnershipController : Controller
+public partial class LimitedPartnershipController : ControllerBase<OrganisationSession>
 {
     private readonly ISessionManager<OrganisationSession> _sessionManager;
 
-    public LimitedPartnershipController(ISessionManager<OrganisationSession> sessionManager)
+    public LimitedPartnershipController(ISessionManager<OrganisationSession> sessionManager) : base(sessionManager)
     {
         _sessionManager = sessionManager;
     }
@@ -365,58 +364,5 @@ public partial class LimitedPartnershipController : Controller
         }
 
         return partnersSession;
-    }
-
-    [ExcludeFromCodeCoverage(Justification = "Going to be refactored into separate common classes")]
-    private void SetBackLink(OrganisationSession session, string currentPagePath)
-    {
-        if (session.IsUserChangingDetails && currentPagePath != PagePath.CheckYourDetails)
-        {
-            ViewBag.BackLinkToDisplay = PagePath.CheckYourDetails;
-        }
-        else
-        {
-            ViewBag.BackLinkToDisplay = session.Journey.PreviousOrDefault(currentPagePath) ?? string.Empty;
-        }
-    }
-
-    [ExcludeFromCodeCoverage(Justification = "Going to be refactored into separate common classes")]
-    private async Task<RedirectToActionResult> SaveSessionAndRedirect(OrganisationSession session,
-        string actionName, string currentPagePath, string? nextPagePath)
-    {
-        session.IsUserChangingDetails = false;
-        await SaveSession(session, currentPagePath, nextPagePath);
-
-        return RedirectToAction(actionName);
-    }
-
-    [ExcludeFromCodeCoverage(Justification = "Going to be refactored into separate common classes")]
-    private async Task<RedirectToActionResult> SaveSessionAndRedirect(OrganisationSession session,
-    string controllerName, string actionName, string currentPagePath, string? nextPagePath)
-    {
-        session.IsUserChangingDetails = false;
-        var contNameWOCont = controllerName.Replace("Controller", string.Empty);
-        await SaveSession(session, currentPagePath, nextPagePath);
-
-        return RedirectToAction(actionName, contNameWOCont);
-    }
-
-    [ExcludeFromCodeCoverage(Justification = "Going to be refactored into separate common classes")]
-    private async Task SaveSession(OrganisationSession session, string currentPagePath, string? nextPagePath)
-    {
-        ClearRestOfJourney(session, currentPagePath);
-
-        session.Journey.AddIfNotExists(nextPagePath);
-
-        await _sessionManager.SaveSessionAsync(HttpContext.Session, session);
-    }
-
-    [ExcludeFromCodeCoverage(Justification = "Going to be refactored into separate common classes")]
-    private static void ClearRestOfJourney(OrganisationSession session, string currentPagePath)
-    {
-        var index = session.Journey.IndexOf(currentPagePath);
-
-        // this also cover if current page not found (index = -1) then it clears all pages
-        session.Journey = session.Journey.Take(index + 1).ToList();
     }
 }

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/LimitedPartnershipController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/LimitedPartnershipController.cs
@@ -2,6 +2,7 @@
 using FrontendAccountCreation.Core.Sessions.ReEx;
 using FrontendAccountCreation.Core.Sessions.ReEx.Partnership;
 using FrontendAccountCreation.Web.Constants;
+using FrontendAccountCreation.Web.Controllers;
 using FrontendAccountCreation.Web.Controllers.Attributes;
 using FrontendAccountCreation.Web.Sessions;
 using FrontendAccountCreation.Web.ViewModels.ReExAccount;

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/OrganisationController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/OrganisationController.cs
@@ -1,5 +1,4 @@
-﻿using FrontendAccountCreation.Core.Extensions;
-using FrontendAccountCreation.Core.Services;
+﻿using FrontendAccountCreation.Core.Services;
 using FrontendAccountCreation.Core.Services.Dto.Company;
 using FrontendAccountCreation.Core.Sessions;
 using FrontendAccountCreation.Core.Sessions.ReEx;

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/OrganisationController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/OrganisationController.cs
@@ -23,7 +23,7 @@ namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter;
 
 [Feature(FeatureFlags.AddOrganisationCompanyHouseDirectorJourney)]
 [Route("re-ex/organisation")]
-public class OrganisationController : Controller
+public class OrganisationController : ControllerBase<OrganisationSession>
 {
     private readonly ISessionManager<OrganisationSession> _sessionManager;
     private readonly IFacadeService _facadeService;
@@ -40,7 +40,7 @@ public class OrganisationController : Controller
          IOrganisationMapper organisationMapper,
          IOptions<ExternalUrlsOptions> urlOptions,
          IOptions<DeploymentRoleOptions> deploymentRoleOptions,
-         ILogger<OrganisationController> logger)
+         ILogger<OrganisationController> logger) : base(sessionManager)
     {
         _sessionManager = sessionManager;
         _facadeService = facadeService;
@@ -615,53 +615,6 @@ public class OrganisationController : Controller
     }
 
     #region Private Methods 
-
-    private void SetBackLink(OrganisationSession session, string currentPagePath)
-    {
-        if (session.IsUserChangingDetails && currentPagePath != PagePath.CheckYourDetails)
-        {
-            ViewBag.BackLinkToDisplay = PagePath.CheckYourDetails;
-        }
-        else
-        {
-            ViewBag.BackLinkToDisplay = session.Journey.PreviousOrDefault(currentPagePath) ?? string.Empty;
-        }
-    }
-
-    private async Task<RedirectToActionResult> SaveSessionAndRedirect(OrganisationSession session,
-        string actionName, string currentPagePath, string? nextPagePath)
-    {
-        session.IsUserChangingDetails = false;
-        await SaveSession(session, currentPagePath, nextPagePath);
-
-        return RedirectToAction(actionName);
-    }
-
-    private async Task<RedirectToActionResult> SaveSessionAndRedirect(OrganisationSession session,
-    string controllerName, string actionName, string currentPagePath, string? nextPagePath)
-    {
-        session.IsUserChangingDetails = false;
-        var contNameWOCont = controllerName.Replace("Controller", string.Empty);
-        await SaveSession(session, currentPagePath, nextPagePath);
-
-        return RedirectToAction(actionName, contNameWOCont);
-    }
-
-    private async Task SaveSession(OrganisationSession session, string currentPagePath, string? nextPagePath)
-    {
-        ClearRestOfJourney(session, currentPagePath);
-
-        session.Journey.AddIfNotExists(nextPagePath);
-
-        await _sessionManager.SaveSessionAsync(HttpContext.Session, session);
-    }
-    private static void ClearRestOfJourney(OrganisationSession session, string currentPagePath)
-    {
-        var index = session.Journey.IndexOf(currentPagePath);
-
-        // this also cover if current page not found (index = -1) then it clears all pages
-        session.Journey = session.Journey.Take(index + 1).ToList();
-    }
 
     private static ModelStateDictionary DeserializeModelState(string serializedModelState)
     {

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/OrganisationController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/OrganisationController.cs
@@ -5,6 +5,7 @@ using FrontendAccountCreation.Core.Sessions;
 using FrontendAccountCreation.Core.Sessions.ReEx;
 using FrontendAccountCreation.Web.Configs;
 using FrontendAccountCreation.Web.Constants;
+using FrontendAccountCreation.Web.Controllers;
 using FrontendAccountCreation.Web.Controllers.Attributes;
 using FrontendAccountCreation.Web.Controllers.Errors;
 using FrontendAccountCreation.Web.Sessions;

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/UserController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/UserController.cs
@@ -19,7 +19,7 @@ namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter;
 /// </summary>
 [Route("re-ex/user")]
 [Feature(FeatureFlags.ReprocessorExporter)]
-public class UserController : Controller
+public class UserController : ControllerBase<ReExAccountCreationSession>
 {
     private readonly ISessionManager<ReExAccountCreationSession> _sessionManager;
     private readonly IFacadeService _facadeService;
@@ -34,7 +34,7 @@ public class UserController : Controller
         IReExAccountMapper reExAccountMapper,
         IOptions<ExternalUrlsOptions> urlOptions,
         IOptions<ServiceKeysOptions> serviceKeyOptions,
-        ILogger<UserController> logger)
+        ILogger<UserController> logger) : base(sessionManager)
     {
         _sessionManager = sessionManager;
         _facadeService = facadeService;
@@ -169,34 +169,4 @@ public class UserController : Controller
     private string? GetUserEmail() => User.Claims.FirstOrDefault(claim => claim.Type == ClaimTypes.Email)?.Value ??
                                       // Remove when we migrate all environments to custom policy
                                       User.Claims.FirstOrDefault(claim => claim.Type == "emails")?.Value;
-
-    private async Task<RedirectToActionResult> SaveSessionAndRedirect(ReExAccountCreationSession session,
-        string actionName, string currentPagePath, string? nextPagePath)
-    {
-        await SaveSession(session, currentPagePath, nextPagePath);
-
-        return RedirectToAction(actionName);
-    }
-
-    private async Task SaveSession(ReExAccountCreationSession session, string currentPagePath, string? nextPagePath)
-    {
-        ClearRestOfJourney(session, currentPagePath);
-
-        session.Journey.AddIfNotExists(nextPagePath);
-
-        await _sessionManager.SaveSessionAsync(HttpContext.Session, session);
-    }
-
-    private static void ClearRestOfJourney(ReExAccountCreationSession session, string currentPagePath)
-    {
-        var index = session.Journey.IndexOf(currentPagePath);
-
-        // this also cover if current page not found (index = -1) then it clears all pages
-        session.Journey = session.Journey.Take(index + 1).ToList();
-    }
-
-    private void SetBackLink(ReExAccountCreationSession session, string currentPagePath)
-    {
-        ViewBag.BackLinkToDisplay = session.Journey.PreviousOrDefault(currentPagePath) ?? string.Empty;
-    }
 }

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/UserController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/UserController.cs
@@ -5,6 +5,7 @@ using FrontendAccountCreation.Core.Sessions;
 using FrontendAccountCreation.Core.Sessions.ReEx;
 using FrontendAccountCreation.Web.Configs;
 using FrontendAccountCreation.Web.Constants;
+using FrontendAccountCreation.Web.Controllers;
 using FrontendAccountCreation.Web.Controllers.Attributes;
 using FrontendAccountCreation.Web.Sessions;
 using FrontendAccountCreation.Web.ViewModels.ReExAccount;

--- a/src/FrontendAccountCreation.Web/Extensions/StringExtensions.cs
+++ b/src/FrontendAccountCreation.Web/Extensions/StringExtensions.cs
@@ -1,0 +1,14 @@
+﻿namespace FrontendAccountCreation.Web.Extensions;
+
+public static class StringExtensions
+{
+    public static string WithoutControllerSuffix(this string controllerName)
+    {
+        if (!string.IsNullOrEmpty(controllerName) && controllerName.ToLowerInvariant().EndsWith("controller"))
+        {
+            controllerName = controllerName.Remove(controllerName.Length - "controller".Length);
+        }
+
+        return controllerName;
+    }
+}

--- a/src/FrontendAccountCreation.Web/Resources/Views/LimitedPartnership/LimitedPartnershipType.cy.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/LimitedPartnership/LimitedPartnershipType.cy.resx
@@ -23,10 +23,10 @@
     <value>[Welsh]Which type of partners are in your limited partnership?</value>
   </data>
   <data name="LimitedPartnershipType.IndividualPartners" xml:space="preserve">
-    <value>[Welsh]Corporate partners</value>
+    <value>[Welsh]Individual partners</value>
   </data>
   <data name="LimitedPartnershipType.CompanyPartners" xml:space="preserve">
-    <value>[Welsh]Company partners</value>
+    <value>[Welsh]Corporate partners</value>
   </data>
   <data name="LimitedPartnershipType.ErrorMessage" xml:space="preserve">
     <value>[Welsh]Select at least one checkbox</value>

--- a/src/FrontendAccountCreation.Web/Resources/Views/LimitedPartnership/LimitedPartnershipType.en.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/LimitedPartnership/LimitedPartnershipType.en.resx
@@ -23,10 +23,10 @@
     <value>Which type of partners are in your limited partnership?</value>
   </data>
   <data name="LimitedPartnershipType.IndividualPartners" xml:space="preserve">
-    <value>Corporate partners</value>
+    <value>Individual partners</value>
   </data>
   <data name="LimitedPartnershipType.CompanyPartners" xml:space="preserve">
-    <value>Company partners</value>
+    <value>Corporate partners</value>
   </data>
   <data name="LimitedPartnershipType.ErrorMessage" xml:space="preserve">
     <value>Select at least one checkbox</value>


### PR DESCRIPTION
Several controllers contain duplicate logic to update the session and redirect. Centralise code in one place so it can be reused and is more maintainable going forward.

Refer to https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/558441