### PR TITLE
AB#566560 map roles to job title on database

### DIFF
--- a/src/FrontendAccountCreation.Core.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/FrontendAccountCreation.Core.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -1,10 +1,6 @@
 ﻿using FluentAssertions;
 using FrontendAccountCreation.Core.Extensions;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FrontendAccountCreation.Core.UnitTests.Extensions
 {
@@ -18,6 +14,7 @@ namespace FrontendAccountCreation.Core.UnitTests.Extensions
 
         Third // No description
     }
+
     [TestClass]
     public class EnumExtensionsTests
     {
@@ -34,5 +31,17 @@ namespace FrontendAccountCreation.Core.UnitTests.Extensions
             description.Should().Be(expected);
         }
 
+        [TestMethod]
+        [DataRow(Test.First, "First Value")]
+        [DataRow(Test.Second, "Second Value")]
+        [DataRow(Test.Third, null)]
+        public void GetDescriptionOrNull_ReturnsExpectedDescription(Test value, string expected)
+        {
+            // Act
+            var description = value.GetDescriptionOrNull();
+
+            // Assert
+            description.Should().Be(expected);
+        }
     }
 }

--- a/src/FrontendAccountCreation.Core.UnitTests/ReExAccountMapperTests.cs
+++ b/src/FrontendAccountCreation.Core.UnitTests/ReExAccountMapperTests.cs
@@ -48,8 +48,10 @@ namespace FrontendAccountCreation.Core.UnitTests
 
         [TestMethod]
         [DataRow(null, null, null, null)]
-        [DataRow(RoleInOrganisation.Director, ReExTeamMemberRole.Director, "Director", "Director")]
-        [DataRow(RoleInOrganisation.Director, ReExTeamMemberRole.CompanySecretary, "Director", "CompanySecretary")]
+        [DataRow(RoleInOrganisation.Director, ReExTeamMemberRole.PartnerDirector, "Company director of a corporate partner", "Company director of a corporate partner")]
+        [DataRow(RoleInOrganisation.Director, ReExTeamMemberRole.PartnerCompanySecretary, "Company director of a corporate partner", "Company secretary of a corporate partner")]
+        [DataRow(RoleInOrganisation.Partner, ReExTeamMemberRole.IndividualPartner, "Individual partner", "Individual partner")]
+        [DataRow(RoleInOrganisation.NoneOfTheAbove, ReExTeamMemberRole.None, null, null)]
         public void CreateReExOrganisationModel_Returns_ValidModel_FromOrganisationSession(RoleInOrganisation? roleInOrg, ReExTeamMemberRole? teamMemberRole, string? expectedRole, string? expectedTeamMember)
         {
             // Arrange
@@ -128,7 +130,7 @@ namespace FrontendAccountCreation.Core.UnitTests
                 {
                     second.FirstName.Should().Be("Jill");
                     second.LastName.Should().Be("Handerson");
-                    second.Role.Should().Be("CompanySecretary");
+                    second.Role.Should().BeNull();
                     second.Email.Should().NotBeNullOrWhiteSpace();
                 });
         }

--- a/src/FrontendAccountCreation.Core/Extensions/EnumExtensions.cs
+++ b/src/FrontendAccountCreation.Core/Extensions/EnumExtensions.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FrontendAccountCreation.Core.Extensions
 {
@@ -16,6 +12,13 @@ namespace FrontendAccountCreation.Core.Extensions
             var field = value.GetType().GetField(value.ToString());
             var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
             return attribute?.Description ?? value.ToString();
+        }
+
+        public static string GetDescriptionOrNull(this Enum value)
+        {
+            var field = value.GetType().GetField(value.ToString());
+            var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+            return attribute?.Description;
         }
     }
 }

--- a/src/FrontendAccountCreation.Core/Services/ReExAccountMapper.cs
+++ b/src/FrontendAccountCreation.Core/Services/ReExAccountMapper.cs
@@ -27,7 +27,7 @@ public class ReExAccountMapper : IReExAccountMapper
     {
         return new ReExOrganisationModel
         {
-            UserRoleInOrganisation = reExOrganisationSession.ReExCompaniesHouseSession.RoleInOrganisation?.ToString() ?? null,
+            UserRoleInOrganisation = reExOrganisationSession.ReExCompaniesHouseSession.RoleInOrganisation?.GetDescriptionOrNull() ?? null,
             IsApprovedUser = reExOrganisationSession.IsApprovedUser,
             Company = new ReExCompanyModel()
             {
@@ -83,7 +83,7 @@ public class ReExAccountMapper : IReExAccountMapper
                 FirstName = member.FirstName,
                 LastName = member.LastName,
                 Email = member.Email,
-                Role = member.Role?.ToString() ?? null,
+                Role = member.Role?.GetDescriptionOrNull() ?? null,
                 TelephoneNumber = member.TelephoneNumber
             };
 

--- a/src/FrontendAccountCreation.Core/Sessions/ReEx/ReExTeamMemberRole.cs
+++ b/src/FrontendAccountCreation.Core/Sessions/ReEx/ReExTeamMemberRole.cs
@@ -1,12 +1,22 @@
-﻿namespace FrontendAccountCreation.Core.Sessions.ReEx;
+﻿using System.ComponentModel;
 
+namespace FrontendAccountCreation.Core.Sessions.ReEx;
+
+// Description decorator is used to map the value to a string, for saving to the database
 public enum ReExTeamMemberRole
 {
     None = 0,
     Director = 1,
     CompanySecretary = 2,
+
+    [Description("Company director of a corporate partner")]
     PartnerDirector = 3,
+
+    [Description("Company secretary of a corporate partner")]
     PartnerCompanySecretary = 4,
+
+    [Description("Individual partner")]
     IndividualPartner = 5,
+
     Member = 6
 }

--- a/src/FrontendAccountCreation.Core/Sessions/RoleInOrganisation.cs
+++ b/src/FrontendAccountCreation.Core/Sessions/RoleInOrganisation.cs
@@ -1,10 +1,20 @@
+using System.ComponentModel;
+
 namespace FrontendAccountCreation.Core.Sessions;
 
+// Description decorator is used to map the value to a string, for saving to the database
 public enum RoleInOrganisation
 {
     NoneOfTheAbove = 0,
+
+    [Description("Company director of a corporate partner")]
     Director = 1,
-    CompanySecretary = 2, 
+
+    [Description("Company secretary of a corporate partner")]
+    CompanySecretary = 2,
+
+    [Description("Individual partner")]
     Partner = 3,
+
     Member = 4
 }

--- a/src/FrontendAccountCreation.Web/Resources/Views/LimitedPartnership/LimitedPartnershipRole.cy.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/LimitedPartnership/LimitedPartnershipRole.cy.resx
@@ -20,16 +20,16 @@
     <value>[Welsh]What role do you have within the limited partnership, as registered on Companies House?</value>
   </data>
   <data name="LimitedPartnershipRole.IndividualPartner" xml:space="preserve">
-    <value>[Welsh]Individual partner</value>
+    <value>[Welsh]Individual partner within the partnership</value>
   </data>
   <data name="LimitedPartnershipRole.CompanyDirector" xml:space="preserve">
-    <value>[Welsh]Company director within an organisation partner</value>
+    <value>[Welsh]Company director of a corporate partner within the partnership</value>
   </data>
   <data name="LimitedPartnershipRole.CompanySecretary" xml:space="preserve">
-    <value>[Welsh]Company secretary within an organisation partner</value>
+    <value>[Welsh]Company secretary of a corporate partner within the partnership</value>
   </data>
     <data name="LimitedPartnershipRole.None" xml:space="preserve">
-    <value>[Welsh]None</value>
+    <value>[Welsh]None of the above</value>
   </data>
   <data name="LimitedPartnershipRole.ErrorMessage" xml:space="preserve">
     <value>[Welsh]Select your role in your organisation</value>

--- a/src/FrontendAccountCreation.Web/Resources/Views/LimitedPartnership/LimitedPartnershipRole.en.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/LimitedPartnership/LimitedPartnershipRole.en.resx
@@ -23,16 +23,16 @@
     <value>What role do you have within the limited partnership, as registered on Companies House?</value>
   </data>
   <data name="LimitedPartnershipRole.IndividualPartner" xml:space="preserve">
-    <value>Individual partner</value>
+    <value>Individual partner within the partnership</value>
   </data>
   <data name="LimitedPartnershipRole.CompanyDirector" xml:space="preserve">
-    <value>Company director within an organisation partner</value>
+    <value>Company director of a corporate partner within the partnership</value>
   </data>
   <data name="LimitedPartnershipRole.CompanySecretary" xml:space="preserve">
-    <value>Company secretary within an organisation partner</value>
+    <value>Company secretary of a corporate partner within the partnership</value>
   </data>
     <data name="LimitedPartnershipRole.None" xml:space="preserve">
-    <value>None</value>
+    <value>None of the above</value>
   </data>
   <data name="LimitedPartnershipRole.ErrorMessage" xml:space="preserve">
     <value>Select your role in your organisation</value>

--- a/src/FrontendAccountCreation.Web/Resources/Views/Shared/Partials/_TeamMemberRoleRadios.cy.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/Shared/Partials/_TeamMemberRoleRadios.cy.resx
@@ -117,19 +117,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApprovedPersonPartnershipRole.CompanySecretary" xml:space="preserve">
-    <value>[Welsh]Company Secretary within an organisation partner</value>
+  <data name="_TeamMemberRoleRadios.IndividualPartner" xml:space="preserve">
+    <value>[Welsh]Individual partner within the partnership</value>
   </data>
-  <data name="ApprovedPersonPartnershipRole.Director" xml:space="preserve">
-    <value>[Welsh]Director within an organisation partner</value>
+  <data name="_TeamMemberRoleRadios.CompanyDirector" xml:space="preserve">
+    <value>[Welsh]Company director of a corporate partner within the partnership</value>
   </data>
-  <data name="ApprovedPersonPartnershipRole.NoneOfTheAbove" xml:space="preserve">
-    <value>[Welsh]None Of The Above</value>
+  <data name="_TeamMemberRoleRadios.CompanySecretary" xml:space="preserve">
+    <value>[Welsh]Company secretary of a corporate partner within the partnership</value>
   </data>
-  <data name="ApprovedPersonPartnershipRole.IndividualPartner" xml:space="preserve">
-    <value>[Welsh]Individual Partner</value>
+    <data name="_TeamMemberRoleRadios.None" xml:space="preserve">
+    <value>[Welsh]None of the above</value>
   </data>
-  <data name="ApprovedPersonPartnershipRole.Or" xml:space="preserve">
-    <value>[Welsh]Or</value>
+  <data name="_TeamMemberRoleRadios.Or" xml:space="preserve">
+    <value>[Welsh]or</value>
   </data>
 </root>

--- a/src/FrontendAccountCreation.Web/Resources/Views/Shared/Partials/_TeamMemberRoleRadios.en.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/Shared/Partials/_TeamMemberRoleRadios.en.resx
@@ -117,19 +117,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApprovedPersonPartnershipRole.CompanySecretary" xml:space="preserve">
-    <value>Company Secretary within an organisation partner</value>
+  <data name="_TeamMemberRoleRadios.IndividualPartner" xml:space="preserve">
+    <value>Individual partner within the partnership</value>
   </data>
-  <data name="ApprovedPersonPartnershipRole.Director" xml:space="preserve">
-    <value>Director within an organisation partner</value>
+  <data name="_TeamMemberRoleRadios.CompanyDirector" xml:space="preserve">
+    <value>Company director of a corporate partner within the partnership</value>
   </data>
-  <data name="ApprovedPersonPartnershipRole.NoneOfTheAbove" xml:space="preserve">
-    <value>None Of The Above</value>
+  <data name="_TeamMemberRoleRadios.CompanySecretary" xml:space="preserve">
+    <value>Company secretary of a corporate partner within the partnership</value>
   </data>
-  <data name="ApprovedPersonPartnershipRole.IndividualPartner" xml:space="preserve">
-    <value>Individual Partner</value>
+    <data name="_TeamMemberRoleRadios.None" xml:space="preserve">
+    <value>None of the above</value>
   </data>
-  <data name="ApprovedPersonPartnershipRole.Or" xml:space="preserve">
-    <value>Or</value>
+  <data name="_TeamMemberRoleRadios.Or" xml:space="preserve">
+    <value>or</value>
   </data>
 </root>

--- a/src/FrontendAccountCreation.Web/Views/Shared/Partials/_TeamMemberRoleRadios.cshtml
+++ b/src/FrontendAccountCreation.Web/Views/Shared/Partials/_TeamMemberRoleRadios.cshtml
@@ -12,7 +12,7 @@
                gov-for="RoleInOrganisation"
                gov-value="@nameof(ReExTeamMemberRole.IndividualPartner)"
                gov-first-option="true">
-            @Localizer["ApprovedPersonPartnershipRole.IndividualPartner"]
+            @Localizer["_TeamMemberRoleRadios.IndividualPartner"]
         </label>
     </div>
     <div class="govuk-radios__item">
@@ -22,7 +22,7 @@
         <label class="govuk-label govuk-radios__label"
                gov-for="RoleInOrganisation"
                gov-value="@nameof(ReExTeamMemberRole.PartnerDirector)">
-            @Localizer["ApprovedPersonPartnershipRole.Director"]
+            @Localizer["_TeamMemberRoleRadios.CompanyDirector"]
         </label>
     </div>
     <div class="govuk-radios__item">
@@ -32,11 +32,11 @@
         <label class="govuk-label govuk-radios__label"
                gov-for="RoleInOrganisation"
                gov-value="@nameof(ReExTeamMemberRole.PartnerCompanySecretary)">
-            @Localizer["ApprovedPersonPartnershipRole.CompanySecretary"]
+            @Localizer["_TeamMemberRoleRadios.CompanySecretary"]
         </label>
     </div>
     <div class="govuk-radios__divider">
-        @Localizer["ApprovedPersonPartnershipRole.Or"]
+        @Localizer["_TeamMemberRoleRadios.Or"]
     </div>
     <div class="govuk-radios__item">
         <input class="govuk-radios__input" type="radio" id="rdoNone"
@@ -45,7 +45,7 @@
         <label class="govuk-label govuk-radios__label"
                gov-for="RoleInOrganisation"
                gov-value="@nameof(ReExTeamMemberRole.None)">
-            @Localizer["ApprovedPersonPartnershipRole.NoneOfTheAbove"]
+            @Localizer["_TeamMemberRoleRadios.None"]
         </label>
     </div>
 </div>


### PR DESCRIPTION
The pages should show:

- Individual partner within the partnership
- Company director of a corporate partner within the partnership
- Company secretary of a corporate partner within the partnership
- None of the above

And the mappings between roles and job titles are:

- Individual partner within the partnership -> Individual partner
- Company director of a corporate partner within the partnership -> Company director of a corporate partner
- Company secretary of a corporate partner within the partnership -> Company secretary of a corporate partner
- None of the above - Blank

Refer to https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/566560

