### PR TITLE
579960 Potential fix for intermittent auth issues

### DIFF
--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/OrganisationController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/OrganisationController.cs
@@ -23,6 +23,7 @@ namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter;
 
 [Feature(FeatureFlags.AddOrganisationCompanyHouseDirectorJourney)]
 [Route("re-ex/organisation")]
+[AuthorizeForScopes(ScopeKeySection = ConfigKeys.FacadeScope)]
 public class OrganisationController : ControllerBase<OrganisationSession>
 {
     private readonly ISessionManager<OrganisationSession> _sessionManager;
@@ -502,7 +503,6 @@ public class OrganisationController : ControllerBase<OrganisationSession>
     }
 
     [HttpPost]
-    [AuthorizeForScopes(ScopeKeySection = ConfigKeys.FacadeScope)]
     [Route(PagePath.CompaniesHouseNumber)]
     public async Task<IActionResult> CompaniesHouseNumber(ReExCompaniesHouseNumberViewModel model)
     {
@@ -884,7 +884,6 @@ public class OrganisationController : ControllerBase<OrganisationSession>
 
     [HttpGet]
     [Route(PagePath.DeclarationContinue)]
-    [AuthorizeForScopes(ScopeKeySection = ConfigKeys.FacadeScope)]
     public async Task<IActionResult> DeclarationContinue()
     {
         var session = await _sessionManager.GetSessionAsync(HttpContext.Session);

--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/UserController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/UserController.cs
@@ -3,7 +3,6 @@ using FrontendAccountCreation.Core.Services;
 using FrontendAccountCreation.Core.Sessions;
 using FrontendAccountCreation.Web.Configs;
 using FrontendAccountCreation.Web.Constants;
-using FrontendAccountCreation.Web.Controllers;
 using FrontendAccountCreation.Web.Controllers.Attributes;
 using FrontendAccountCreation.Web.Sessions;
 using FrontendAccountCreation.Web.ViewModels.ReExAccount;
@@ -18,6 +17,7 @@ namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter;
 /// </summary>
 [Route("re-ex/user")]
 [Feature(FeatureFlags.ReprocessorExporter)]
+[AuthorizeForScopes(ScopeKeySection = ConfigKeys.FacadeScope)]
 public class UserController : ControllerBase<ReExAccountCreationSession>
 {
     private readonly ISessionManager<ReExAccountCreationSession> _sessionManager;
@@ -141,7 +141,6 @@ public class UserController : ControllerBase<ReExAccountCreationSession>
     }
 
     [HttpGet]
-    [AuthorizeForScopes(ScopeKeySection = ConfigKeys.FacadeScope)]
     [Route(PagePath.Success)]
     [ReprocessorExporterJourneyAccess(PagePath.Success)]
     public async Task<IActionResult> Success()


### PR DESCRIPTION
The AuthorizeForScopes attribute is required for any method handlers that call the facade, but it's often forgotten or overlooked, so this adds it at the controller level.