### PR TITLE
AB#581171 Resource changes add approved person validation failure message

### DIFF
--- a/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/ApprovedPersonController.cs
+++ b/src/FrontendAccountCreation.Web/Controllers/ReprocessorExporter/ApprovedPersonController.cs
@@ -1291,6 +1291,9 @@ namespace FrontendAccountCreation.Web.Controllers.ReprocessorExporter
                 SetBackLink(session, PagePath.NonCompaniesHousePartnershipInviteApprovedPerson);
                 model.IsNonCompaniesHousePartnership = session.ReExManualInputSession?.ProducerType == ProducerType.Partnership;
 
+                ModelState.ClearValidationState(nameof(model.InviteUserOption));
+                ModelState.AddModelError(nameof(model.InviteUserOption), ApprovedPersonErrorMessage);
+
                 return View(model);
             }
 

--- a/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHousePartnershipAddApprovedPerson.cy.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHousePartnershipAddApprovedPerson.cy.resx
@@ -58,7 +58,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NonCompaniesHousePartnershipAddApprovedPerson.OptionError" xml:space="preserve">
+  <data name="AddAnApprovedPerson.OptionError" xml:space="preserve">
     <value>[Welsh]Select whether to be an approved person, invite someone else to be one or do this later</value>
     <comment>f</comment>
   </data>

--- a/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHousePartnershipAddApprovedPerson.en.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHousePartnershipAddApprovedPerson.en.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NonCompaniesHousePartnershipAddApprovedPerson.OptionError" xml:space="preserve">
+  <data name="AddAnApprovedPerson.OptionError" xml:space="preserve">
     <value>Select whether to be an approved person, invite someone else to be one or do this later</value>
     <comment>f</comment>
   </data>

--- a/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHousePartnershipInviteApprovedPerson.cy.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHousePartnershipInviteApprovedPerson.cy.resx
@@ -59,6 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NonCompaniesHousePartnershipInviteApprovedPerson.Title" xml:space="preserve">
-    <value>[Welsh]Invite-an-approved-person</value>
+    <value>[Welsh]Add an approved person</value>
+  </data>
+  <data name="AddAnApprovedPerson.OptionError" xml:space="preserve">
+    <value>[Welsh]Select whether to invite someone to be an approved person or do this later</value>
   </data>
 </root>

--- a/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHousePartnershipInviteApprovedPerson.en.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHousePartnershipInviteApprovedPerson.en.resx
@@ -59,6 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NonCompaniesHousePartnershipInviteApprovedPerson.Title" xml:space="preserve">
-    <value>Invite-an-approved-person</value>
+    <value>Add an approved person</value>
+  </data>
+  <data name="AddAnApprovedPerson.OptionError" xml:space="preserve">
+    <value>Select whether to invite someone to be an approved person or do this later</value>
   </data>
 </root>


### PR DESCRIPTION
On Add Approved Persons pages, the validation error when the user does not select a radio button is incorrect. Add resources to show validation warning message in English and Welsh.

Refer to https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/581171