### PR TITLE
AB#567799 remove "instead" from end of sentence in localizer

### DIFF
--- a/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/Partials/_InEligibleAddNotApprovedPerson.cy.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/Partials/_InEligibleAddNotApprovedPerson.cy.resx
@@ -148,7 +148,7 @@
     <value>[Welsh]More than one person can be invited - you will need to confirm their role, enter their name and contact details.</value>
   </data>
   <data name="InEligibleAddNotApprovedPerson.IWillInviteAnotherApprovedPerson" xml:space="preserve">
-    <value>[Welsh]I will invite another eligible person to be an approved person instead</value>
+    <value>[Welsh]I will invite another eligible person to be an approved person</value>
   </data>
   <data name="InEligibleAddNotApprovedPerson.IWillInviteApprovedPersonLater" xml:space="preserve">
     <value>[Welsh]I will invite an approved person later</value>

--- a/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/Partials/_InEligibleAddNotApprovedPerson.en.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/Partials/_InEligibleAddNotApprovedPerson.en.resx
@@ -148,7 +148,7 @@
     <value>More than one person can be invited - you will need to confirm their role, enter their name and contact details.</value>
   </data>
   <data name="InEligibleAddNotApprovedPerson.IWillInviteAnotherApprovedPerson" xml:space="preserve">
-    <value>I will invite another eligible person to be an approved person instead</value>
+    <value>I will invite another eligible person to be an approved person</value>
   </data>
   <data name="InEligibleAddNotApprovedPerson.IWillInviteApprovedPersonLater" xml:space="preserve">
     <value>I will invite an approved person later</value>


### PR DESCRIPTION
Bug

I will invite an eligible person to be an approved person instead

=>

I will invite an eligible person to be an approved person

Refer to https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/567799