### PR TITLE
AB#589568 fix typo on add approved person radio button text

### DIFF
--- a/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/Partials/_AddNotApprovedPerson.en.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/Partials/_AddNotApprovedPerson.en.resx
@@ -154,7 +154,7 @@
     <value>I will invite an eligible person to be an approved person</value>
   </data>
   <data name="AddNotApprovedPerson.InviteAnotherApprovedPerson" xml:space="preserve">
-    <value>I will invite a team member to be an approved person instead</value>
+    <value>I will invite an eligible person to be an approved person</value>
   </data>
   <data name="AddNotApprovedPerson.InviteApprovedPersonLater" xml:space="preserve">
     <value>I will invite an approved person later</value>


### PR DESCRIPTION
From:
**I will invite a team member to be an approved person instead**
To:
**I will invite an eligible person to be an approved person**

Curiously, the Welsh translation is already correct, and did not need changing