### PR TITLE
AB#568412-Fix Gapping and styling

### DIFF
--- a/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHouseTeamMemberCheckInvitationDetails.cy.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHouseTeamMemberCheckInvitationDetails.cy.resx
@@ -174,7 +174,7 @@
   <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.PartnerCompanySecretary" xml:space="preserve">
     <value>[Welsh]Company secretary of a corporate partner within the partnership</value>
   </data>
-    <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.None" xml:space="preserve">
+  <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.None" xml:space="preserve">
     <value>[Welsh]None of the above</value>
   </data>
   <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.NoInviterContinueMsg" xml:space="preserve">
@@ -182,5 +182,8 @@
   </data>
   <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.NoInviterRemovedMsg" xml:space="preserve">
     <value>[Welsh]You have removed any invitations created for one or more approved persons.</value>
+  </data>
+  <data name="TeamMemberCheckInvitationDetails.Help" xml:space="preserve">
+    <value>[Welsh] Any invites created for one or more approved persons will be sent once the organisation is added.</value>
   </data>
 </root>

--- a/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHouseTeamMemberCheckInvitationDetails.en.resx
+++ b/src/FrontendAccountCreation.Web/Resources/Views/ApprovedPerson/NonCompaniesHouseTeamMemberCheckInvitationDetails.en.resx
@@ -174,7 +174,7 @@
   <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.PartnerCompanySecretary" xml:space="preserve">
     <value>Company secretary of a corporate partner within the partnership</value>
   </data>
-    <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.None" xml:space="preserve">
+  <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.None" xml:space="preserve">
     <value>None of the above</value>
   </data>
   <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.NoInviterContinueMsg" xml:space="preserve">
@@ -182,5 +182,8 @@
   </data>
   <data name="NonCompaniesHouseTeamMemberCheckInvitationDetails.NoInviterRemovedMsg" xml:space="preserve">
     <value>You have removed any invitations created for one or more approved persons.</value>
+  </data>
+  <data name="TeamMemberCheckInvitationDetails.Help" xml:space="preserve">
+    <value>Any invites created for one or more approved persons will be sent once the organisation is added.</value>
   </data>
 </root>

--- a/src/FrontendAccountCreation.Web/Views/ApprovedPerson/CheckYourDetails.cshtml
+++ b/src/FrontendAccountCreation.Web/Views/ApprovedPerson/CheckYourDetails.cshtml
@@ -168,8 +168,6 @@
                                     </dd>
                                 </div>
 
-                            }
-
                             @if (Model.IsTradingNameDifferent.Value)
                             {
                                 <div class="govuk-summary-list__row">

--- a/src/FrontendAccountCreation.Web/Views/ApprovedPerson/NonCompaniesHouseTeamMemberCheckInvitationDetails.cshtml
+++ b/src/FrontendAccountCreation.Web/Views/ApprovedPerson/NonCompaniesHouseTeamMemberCheckInvitationDetails.cshtml
@@ -49,7 +49,7 @@
                             <dl class="govuk-summary-list">
 
                                 <!-- Role of team member -->
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+                                <div class="govuk-summary-list__row">
                                     <dt class="govuk-summary-list__key">
                                         @Localizer["NonCompaniesHouseTeamMemberCheckInvitationDetails.Role"]
                                     </dt>
@@ -96,15 +96,15 @@
                                         </a>
                                     </dd>
                                 </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions govuk-summary-list__row--no-border">
+                                <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
                                     <dt class="govuk-summary-list__key">@Localizer["NonCompaniesHouseTeamMemberCheckInvitationDetails.LastName"]</dt>
                                     <dd class="govuk-summary-list__value">@Model.TeamMembers[i].LastName</dd>
                                 </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions govuk-summary-list__row--no-border">
+                                <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
                                     <dt class="govuk-summary-list__key">@Localizer["NonCompaniesHouseTeamMemberCheckInvitationDetails.Email"]</dt>
                                     <dd class="govuk-summary-list__value">@Model.TeamMembers[i].Email</dd>
                                 </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+                                <div class="govuk-summary-list__row">
                                     <dt class="govuk-summary-list__key">@Localizer["NonCompaniesHouseTeamMemberCheckInvitationDetails.Telephone"]</dt>
                                     <dd class="govuk-summary-list__value">@Model.TeamMembers[i].TelephoneNumber</dd>
                                 </div>


### PR DESCRIPTION
Fix styling on: View/Page Non companies house/partnership/approved person check details.

Remove extra "}" from check your details

Fix help text on: View/Page Non companies house/partnership/approved person check details.